### PR TITLE
Correctly capture the exception value

### DIFF
--- a/ledsign/__init__.py
+++ b/ledsign/__init__.py
@@ -32,7 +32,7 @@ class LedSign(object):
                     timeout=params['timeout']
                 )
             except serial.serialutil.SerialException:
-                e-sys.exc_info()[1]
+                e=sys.exc_info()[1]
                 raise Exception('Can\'t open serial port: [' + str(e) + ']\n')
 
     def writeserial(this,data):


### PR DESCRIPTION
Just fixes a little typo that you only notice if the sign isn't connected.
